### PR TITLE
Survivor suits update second

### DIFF
--- a/data/json/items/armor/bespoke_armor/custom_bodysuits.json
+++ b/data/json/items/armor/bespoke_armor/custom_bodysuits.json
@@ -434,7 +434,7 @@
     "price_postapoc": 7000,
     "to_hit": -3,
     "bashing": 6,
-    "material": [ "kevlar_layered", "low_steel", "leather" ],
+    "material": [ "kevlar_layered", "tempered_steel", "leather" ],
     "symbol": "[",
     "looks_like": "survivor_suit",
     "color": "dark_gray",
@@ -443,8 +443,8 @@
         "material" : [
           { "type": "leather", "covered_by_mat": 100, "thickness": 0.2 },
           { "type": "kevlar_layered", "covered_by_mat": 100, "thickness": 2 },
-          { "type": "low_steel", "covered_by_mat": 90, "thickness": 1 },
-          { "type": "low_steel", "covered_by_mat": 90, "thickness": 1 }
+          { "type": "tempered_steel", "covered_by_mat": 90, "thickness": 0.6 },
+          { "type": "tempered_steel", "covered_by_mat": 90, "thickness": 0.6 }
         ],
         "covers": [ "torso", "leg_l", "leg_r", "arm_l", "arm_r" ],
         "coverage": 100,

--- a/data/json/items/armor/bespoke_armor/custom_bodysuits.json
+++ b/data/json/items/armor/bespoke_armor/custom_bodysuits.json
@@ -427,7 +427,7 @@
     "type": "ARMOR",
     "category": "armor",
     "name": { "str": "heavy survivor suit" },
-    "description": "A heavy, hand-built combination armor made from a reinforced bulletproof vest and a metal-plated leather jumpsuit.  Protects from the elements as well as from harm.",
+    "description": "A heavy, hand-built combination armor made from tempered steel plates and a leather jumpsuit padded with layered kevlar.  Protects from the elements as well as from harm.",
     "weight": "15500 g",
     "volume": "12 L",
     "price": 200000,

--- a/data/json/recipes/armor/bespoke_armor/survivor.json
+++ b/data/json/recipes/armor/bespoke_armor/survivor.json
@@ -99,7 +99,7 @@
     ],
     "tools": [ [ [ "welder", 28 ], [ "welder_crude", 42 ], [ "soldering_iron", 42 ], [ "toolset", 42 ] ] ],
     "components": [
-      [ [ "rag", 30 ], [ "sheet_cotton_patchwork", 30 ], [ "sheet_cotton", 30 ], [ "jumpsuit", 1 ] ],
+      [ [ "rag", 20 ], [ "sheet_cotton_patchwork", 20 ], [ "sheet_cotton", 20 ], [ "jumpsuit", 1 ] ],
       [ [ "coat_rain", 1 ], [ "jacket_windbreaker", 1 ], [ "jacket_evac", 1 ], [ "coat_gut", 1 ] ],
       [ [ "duct_tape", 200 ] ],
       [ [ "sheet_kevlar_layered", 24 ], [ "kevlar", 1], [ "swat_armor", 1], [ "ballistic_vest_esapi", 1] ]
@@ -113,7 +113,7 @@
     "using": [ [ "sewing_standard", 75 ] ],
     "tools": [ [ [ "welder", 28 ], [ "welder_crude", 42 ], [ "soldering_iron", 42 ], [ "toolset", 42 ] ] ],
     "components": [
-      [ [ "rag", 22 ], [ "sheet_cotton_patchwork", 22 ], [ "sheet_cotton", 22 ], [ "jumpsuit", 1 ] ],
+      [ [ "rag", 15 ], [ "sheet_cotton_patchwork", 15 ], [ "sheet_cotton", 22 ], [ "jumpsuit", 1 ] ],
       [ [ "coat_rain", 1 ], [ "jacket_windbreaker", 1 ], [ "jacket_evac", 1 ], [ "coat_gut", 1 ] ],
       [ [ "duct_tape", 150 ] ],
       [ [ "sheet_kevlar_layered", 18 ], [ "kevlar", 1], [ "swat_armor", 1], [ "ballistic_vest_esapi", 1] ]
@@ -127,7 +127,7 @@
     "using": [ [ "sewing_standard", 150 ] ],
     "tools": [ [ [ "welder", 36 ], [ "welder_crude", 58 ], [ "soldering_iron", 58 ], [ "toolset", 58 ] ] ],
     "components": [
-      [ [ "rag", 45 ], [ "sheet_cotton_patchwork", 45 ], [ "sheet_cotton", 45 ], [ "jumpsuit", 2 ] ],
+      [ [ "rag", 30 ], [ "sheet_cotton_patchwork", 30 ], [ "sheet_cotton", 30 ], [ "jumpsuit", 2 ] ],
       [ [ "coat_rain", 2 ], [ "jacket_windbreaker", 2 ], [ "jacket_evac", 2 ], [ "coat_gut", 2 ] ],
       [ [ "duct_tape", 300 ] ],
       [ [ "sheet_kevlar_layered", 36 ], [ "kevlar", 2], [ "swat_armor", 2], [ "ballistic_vest_esapi", 2] ]
@@ -144,7 +144,7 @@
     "skills_required": [ "fabrication", 6 ],
     "time": "7 h",
     "autolearn": true,
-    "using": [ [ "sewing_standard", 150 ], [ "fabric_standard_nostretch", 20 ] ],
+    "using": [ [ "sewing_standard", 150 ] ],
     "qualities": [ { "id": "LEATHER_AWL", "level": 1 } ],
     "proficiencies": [
       { "proficiency": "prof_leatherworking_basic" },
@@ -155,24 +155,43 @@
     ],
     "tools": [ [ [ "welder", 28 ], [ "welder_crude", 42 ], [ "soldering_iron", 42 ], [ "toolset", 42 ] ] ],
     "components": [
-      [ [ "leather", 20 ], [ "tanned_hide", 4 ] ],
+      [ [ "rag", 10 ], [ "sheet_cotton_patchwork", 10 ], [ "sheet_cotton", 10 ], [ "jumpsuit", 1 ] ],
+      [ [ "leather", 12 ], [ "tanned_hide", 2 ] ],
       [ [ "coat_rain", 1 ], [ "jacket_windbreaker", 1 ], [ "jacket_evac", 1 ], [ "coat_gut", 1 ] ],
       [ [ "duct_tape", 300 ] ],
-      [ [ "sheet_kevlar_layered", 24 ] ]
+      [ [ "sheet_kevlar_layered", 36 ], [ "kevlar", 2], [ "swat_armor", 2], [ "ballistic_vest_esapi", 2], [ "ballistic_vest_heavy", 1 ] ]
     ]
   },
   {
     "result": "xssurvivor_jumpsuit",
     "type": "recipe",
     "copy-from": "survivor_jumpsuit",
+    "activity_level": "LIGHT_EXERCISE",
     "time": "7 h",
-    "using": [ [ "sewing_standard", 112 ], [ "fabric_standard_nostretch", 15 ] ],
+    "using": [ [ "sewing_standard", 112 ] ],
     "tools": [ [ [ "welder", 28 ], [ "welder_crude", 42 ], [ "soldering_iron", 42 ], [ "toolset", 42 ] ] ],
     "components": [
-      [ [ "leather", 15 ], [ "tanned_hide", 3 ] ],
+      [ [ "rag", 7 ], [ "sheet_cotton_patchwork", 7 ], [ "sheet_cotton", 7 ], [ "jumpsuit", 1 ] ],
+      [ [ "leather", 9 ], [ "tanned_hide", 2 ] ],
       [ [ "coat_rain", 1 ], [ "jacket_windbreaker", 1 ], [ "jacket_evac", 1 ], [ "coat_gut", 1 ] ],
       [ [ "duct_tape", 225 ] ],
-      [ [ "sheet_kevlar_layered", 18 ] ]
+      [ [ "sheet_kevlar_layered", 27 ], [ "kevlar", 1], [ "swat_armor", 1], [ "ballistic_vest_esapi", 1], [ "ballistic_vest_heavy", 1 ] ]
+    ]
+  },
+  {
+    "result": "xlsurvivor_jumpsuit",
+    "type": "recipe",
+    "copy-from": "survivor_jumpsuit",
+    "activity_level": "LIGHT_EXERCISE",
+    "time": "8 h 10 m",
+    "using": [ [ "sewing_standard", 200 ] ],
+    "tools": [ [ [ "welder", 56 ], [ "welder_crude", 84 ], [ "soldering_iron", 84 ], [ "toolset", 84 ] ] ],
+    "components": [
+      [ [ "rag", 15 ], [ "sheet_cotton_patchwork", 15 ], [ "sheet_cotton", 15 ], [ "jumpsuit", 2 ] ],
+      [ [ "leather", 18 ], [ "tanned_hide", 3 ] ],
+      [ [ "coat_rain", 2 ], [ "jacket_windbreaker", 2 ], [ "jacket_evac", 2 ], [ "coat_gut", 2 ] ],
+      [ [ "duct_tape", 450 ] ],
+      [ [ "sheet_kevlar_layered", 54 ], [ "kevlar", 3], [ "swat_armor", 3], [ "ballistic_vest_esapi", 3], [ "ballistic_vest_heavy", 2 ] ]
     ]
   },
   {
@@ -243,34 +262,6 @@
       [ [ "coat_rain", 2 ], [ "jacket_windbreaker", 2 ], [ "jacket_evac", 2 ], [ "coat_gut", 2 ] ],
       [ [ "duct_tape", 400 ] ],
       [ [ "sheet_kevlar_layered", 48 ] ]
-    ]
-  },
-  {
-    "result": "xlsurvivor_jumpsuit",
-    "type": "recipe",
-    "activity_level": "LIGHT_EXERCISE",
-    "category": "CC_ARMOR",
-    "subcategory": "CSC_ARMOR_SUIT",
-    "skill_used": "tailor",
-    "difficulty": 6,
-    "skills_required": [ "fabrication", 6 ],
-    "time": "8 h 10 m",
-    "autolearn": true,
-    "using": [ [ "sewing_standard", 200 ], [ "fabric_standard_nostretch", 30 ], [ "fabric_leather_hide", 7 ] ],
-    "qualities": [ { "id": "LEATHER_AWL", "level": 1 } ],
-    "proficiencies": [
-      { "proficiency": "prof_leatherworking_basic" },
-      { "proficiency": "prof_leatherworking" },
-      { "proficiency": "prof_closures" },
-      { "proficiency": "prof_closures_waterproofing" },
-      { "proficiency": "prof_polymerworking" }
-    ],
-    "tools": [ [ [ "welder", 56 ], [ "welder_crude", 84 ], [ "soldering_iron", 84 ], [ "toolset", 84 ] ] ],
-    "components": [
-      [ [ "scrap", 8 ] ],
-      [ [ "coat_rain", 2 ], [ "jacket_windbreaker", 2 ], [ "jacket_evac", 2 ], [ "coat_gut", 2 ] ],
-      [ [ "duct_tape", 400 ] ],
-      [ [ "sheet_kevlar_layered", 42 ] ]
     ]
   },
   {

--- a/data/json/recipes/armor/bespoke_armor/survivor.json
+++ b/data/json/recipes/armor/bespoke_armor/survivor.json
@@ -169,6 +169,7 @@
     "activity_level": "LIGHT_EXERCISE",
     "time": "7 h",
     "using": [ [ "sewing_standard", 112 ] ],
+    "qualities": [ { "id": "LEATHER_AWL", "level": 1 } ],
     "tools": [ [ [ "welder", 28 ], [ "welder_crude", 42 ], [ "soldering_iron", 42 ], [ "toolset", 42 ] ] ],
     "components": [
       [ [ "rag", 7 ], [ "sheet_cotton_patchwork", 7 ], [ "sheet_cotton", 7 ], [ "jumpsuit", 1 ] ],
@@ -185,6 +186,7 @@
     "activity_level": "LIGHT_EXERCISE",
     "time": "8 h 10 m",
     "using": [ [ "sewing_standard", 200 ] ],
+    "qualities": [ { "id": "LEATHER_AWL", "level": 1 } ],
     "tools": [ [ [ "welder", 56 ], [ "welder_crude", 84 ], [ "soldering_iron", 84 ], [ "toolset", 84 ] ] ],
     "components": [
       [ [ "rag", 15 ], [ "sheet_cotton_patchwork", 15 ], [ "sheet_cotton", 15 ], [ "jumpsuit", 2 ] ],

--- a/data/json/recipes/armor/bespoke_armor/survivor.json
+++ b/data/json/recipes/armor/bespoke_armor/survivor.json
@@ -91,7 +91,7 @@
     "skills_required": [ "fabrication", 6 ],
     "time": "6 h",
     "autolearn": true,
-    "using": [ [ "sewing_standard", 100 ], [ "fabric_standard_nostretch", 30 ] ],
+    "using": [ [ "sewing_standard", 100 ] ],
     "proficiencies": [
       { "proficiency": "prof_closures" },
       { "proficiency": "prof_closures_waterproofing" },
@@ -99,9 +99,10 @@
     ],
     "tools": [ [ [ "welder", 28 ], [ "welder_crude", 42 ], [ "soldering_iron", 42 ], [ "toolset", 42 ] ] ],
     "components": [
+      [ [ "rag", 30 ], [ "sheet_cotton_patchwork", 30 ], [ "sheet_cotton", 30 ], [ "jumpsuit", 1 ] ],
       [ [ "coat_rain", 1 ], [ "jacket_windbreaker", 1 ], [ "jacket_evac", 1 ], [ "coat_gut", 1 ] ],
       [ [ "duct_tape", 200 ] ],
-      [ [ "sheet_kevlar_layered", 24 ] ]
+      [ [ "sheet_kevlar_layered", 24 ], [ "kevlar", 1], [ "swat_armor", 1], [ "ballistic_vest_esapi", 1] ]
     ]
   },
   {
@@ -109,12 +110,13 @@
     "type": "recipe",
     "copy-from": "lsurvivor_jumpsuit",
     "time": "6 h",
-    "using": [ [ "sewing_standard", 75 ], [ "fabric_standard_nostretch", 22 ] ],
+    "using": [ [ "sewing_standard", 75 ] ],
     "tools": [ [ [ "welder", 28 ], [ "welder_crude", 42 ], [ "soldering_iron", 42 ], [ "toolset", 42 ] ] ],
     "components": [
+      [ [ "rag", 22 ], [ "sheet_cotton_patchwork", 22 ], [ "sheet_cotton", 22 ], [ "jumpsuit", 1 ] ],
       [ [ "coat_rain", 1 ], [ "jacket_windbreaker", 1 ], [ "jacket_evac", 1 ], [ "coat_gut", 1 ] ],
       [ [ "duct_tape", 150 ] ],
-      [ [ "sheet_kevlar_layered", 18 ] ]
+      [ [ "sheet_kevlar_layered", 18 ], [ "kevlar", 1], [ "swat_armor", 1], [ "ballistic_vest_esapi", 1] ]
     ]
   },
   {
@@ -122,12 +124,13 @@
     "type": "recipe",
     "copy-from": "lsurvivor_jumpsuit",
     "time": "7 h",
-    "using": [ [ "sewing_standard", 150 ], [ "fabric_standard_nostretch", 45 ] ],
+    "using": [ [ "sewing_standard", 150 ] ],
     "tools": [ [ [ "welder", 36 ], [ "welder_crude", 58 ], [ "soldering_iron", 58 ], [ "toolset", 58 ] ] ],
     "components": [
+      [ [ "rag", 45 ], [ "sheet_cotton_patchwork", 45 ], [ "sheet_cotton", 45 ], [ "jumpsuit", 2 ] ],
       [ [ "coat_rain", 2 ], [ "jacket_windbreaker", 2 ], [ "jacket_evac", 2 ], [ "coat_gut", 2 ] ],
       [ [ "duct_tape", 300 ] ],
-      [ [ "sheet_kevlar_layered", 48 ] ]
+      [ [ "sheet_kevlar_layered", 36 ], [ "kevlar", 2], [ "swat_armor", 2], [ "ballistic_vest_esapi", 2] ]
     ]
   },
   {

--- a/data/json/recipes/armor/suit.json
+++ b/data/json/recipes/armor/suit.json
@@ -1369,7 +1369,7 @@
     "skills_required": [ "fabrication", 7 ],
     "time": "20 h",
     "autolearn": true,
-    "using": [ [ "sewing_standard", 200 ], [ "fabric_standard_nostretch", 20 ], [ "fabric_leather_hide", 4 ] ],
+    "using": [ [ "sewing_standard", 200 ] ],
     "proficiencies": [
       { "proficiency": "prof_leatherworking_basic" },
       { "proficiency": "prof_leatherworking" },
@@ -1382,87 +1382,44 @@
     "qualities": [ { "id": "LEATHER_AWL", "level": 1 } ],
     "tools": [ [ [ "welder", 56 ], [ "welder_crude", 84 ], [ "soldering_iron", 84 ], [ "toolset", 84 ] ] ],
     "components": [
-      [ [ "steel_chunk", 4 ], [ "scrap", 12 ], ["lc_steel_lump", 1 ], ["lc_steel_chunk", 4] ],
+      [ [ "rag", 10 ], [ "sheet_cotton_patchwork", 10 ], [ "sheet_cotton", 10 ], [ "jumpsuit", 1 ] ],
+      [ [ "leather", 12 ], [ "tanned_hide", 2 ] ],
       [ [ "coat_rain", 1 ], [ "jacket_windbreaker", 1 ], [ "jacket_evac", 1 ], [ "coat_gut", 1 ] ],
-      [
-        [ "tacvest", 1 ],
-        [ "legrig", 1 ],
-        [ "vest", 1 ],
-        [ "tool_belt", 1 ],
-        [ "ragpouch", 6 ],
-        [ "leather_pouch", 4 ],
-        [ "dump_pouch", 1 ],
-        [ "purse", 2 ],
-        [ "fanny", 2 ]
-      ],
+      [ [ "steel_chunk", 4 ], [ "scrap", 12 ], ["lc_steel_lump", 1 ], ["lc_steel_chunk", 4] ],
       [ [ "duct_tape", 300 ] ],
-      [
-        [ "kevlar", 1 ],
-        [ "ballistic_vest_light", 1 ],
-        [ "ballistic_vest_esapi", 1 ],
-        [ "swat_armor", 1 ],
-        [ "sheet_kevlar_layered", 24 ]
-      ]
+      [ [ "sheet_kevlar_layered", 30 ], [ "kevlar", 2], [ "swat_armor", 2], [ "ballistic_vest_esapi", 2], [ "ballistic_vest_heavy", 1 ] ]
     ]
   },
   {
     "result": "xs_hsurvivor_jumpsuit",
     "type": "recipe",
+    "activity_level": "MODERATE_EXERCISE",
     "copy-from": "hsurvivor_jumpsuit",
     "qualities": [ { "id": "LEATHER_AWL", "level": 1 } ],
     "tools": [ [ [ "welder", 42 ], [ "welder_crude", 63 ], [ "soldering_iron", 63 ], [ "toolset", 63 ] ] ],
     "components": [
-      [ [ "steel_chunk", 3 ], [ "scrap", 9 ], ["lc_steel_lump", 1 ], ["lc_steel_chunk", 3] ],
+      [ [ "rag", 7 ], [ "sheet_cotton_patchwork", 7 ], [ "sheet_cotton", 7 ], [ "jumpsuit", 1 ] ],
+      [ [ "leather", 9 ], [ "tanned_hide", 2 ] ],
       [ [ "coat_rain", 1 ], [ "jacket_windbreaker", 1 ], [ "jacket_evac", 1 ], [ "coat_gut", 1 ] ],
-      [
-        [ "tacvest", 1 ],
-        [ "legrig", 1 ],
-        [ "vest", 1 ],
-        [ "tool_belt", 1 ],
-        [ "ragpouch", 6 ],
-        [ "leather_pouch", 4 ],
-        [ "dump_pouch", 1 ],
-        [ "purse", 2 ],
-        [ "fanny", 2 ]
-      ],
+      [ [ "steel_chunk", 3 ], [ "scrap", 9 ], ["lc_steel_lump", 1 ], ["lc_steel_chunk", 3] ],
       [ [ "duct_tape", 225 ] ],
-      [
-        [ "kevlar", 1 ],
-        [ "ballistic_vest_light", 1 ],
-        [ "ballistic_vest_esapi", 1 ],
-        [ "swat_armor", 1 ],
-        [ "sheet_kevlar_layered", 18 ]
-      ]
+      [ [ "sheet_kevlar_layered", 23 ], [ "kevlar", 1], [ "swat_armor", 2], [ "ballistic_vest_esapi", 1], [ "ballistic_vest_heavy", 1 ] ]
     ]
   },
   {
     "result": "xl_hsurvivor_jumpsuit",
     "type": "recipe",
+    "activity_level": "MODERATE_EXERCISE",
     "copy-from": "hsurvivor_jumpsuit",
     "qualities": [ { "id": "LEATHER_AWL", "level": 1 } ],
     "tools": [ [ [ "welder", 63 ], [ "welder_crude", 95 ], [ "soldering_iron", 95 ], [ "toolset", 95 ] ] ],
     "components": [
-      [ [ "steel_chunk", 5 ], [ "scrap", 15 ], ["lc_steel_lump", 2 ], ["lc_steel_chunk", 5] ],
+      [ [ "rag", 15 ], [ "sheet_cotton_patchwork", 15 ], [ "sheet_cotton", 15 ], [ "jumpsuit", 1 ] ],
+      [ [ "leather", 18 ], [ "tanned_hide", 3 ] ],
       [ [ "coat_rain", 1 ], [ "jacket_windbreaker", 1 ], [ "jacket_evac", 1 ], [ "coat_gut", 1 ] ],
-      [
-        [ "tacvest", 1 ],
-        [ "legrig", 1 ],
-        [ "vest", 1 ],
-        [ "tool_belt", 1 ],
-        [ "ragpouch", 6 ],
-        [ "leather_pouch", 4 ],
-        [ "dump_pouch", 1 ],
-        [ "purse", 2 ],
-        [ "fanny", 2 ]
-      ],
-      [ [ "duct_tape", 340 ] ],
-      [
-        [ "kevlar", 1 ],
-        [ "ballistic_vest_light", 1 ],
-        [ "ballistic_vest_esapi", 1 ],
-        [ "swat_armor", 1 ],
-        [ "sheet_kevlar_layered", 27 ]
-      ]
+      [ [ "steel_chunk", 6 ], [ "scrap", 18 ], ["lc_steel_lump", 2 ], ["lc_steel_chunk", 6] ],
+      [ [ "duct_tape", 450 ] ],
+      [ [ "sheet_kevlar_layered", 45 ], [ "kevlar", 3], [ "swat_armor", 3], [ "ballistic_vest_esapi", 3], [ "ballistic_vest_heavy", 2 ] ]
     ]
   },
   {

--- a/data/json/recipes/armor/suit.json
+++ b/data/json/recipes/armor/suit.json
@@ -1366,29 +1366,45 @@
     "subcategory": "CSC_ARMOR_SUIT",
     "skill_used": "tailor",
     "difficulty": 7,
-    "skills_required": [ "fabrication", 7 ],
+    "skills_required": [
+      "fabrication",
+      7
+    ],
     "time": "20 h",
     "autolearn": true,
-    "using": [ [ "sewing_standard", 200 ] ],
+    "using": [
+      [ "sewing_standard", 200 ],
+      [ "blacksmithing_standard", 10 ],
+      [ "mc_steel_standard", 3 ],
+      [ "fabric_leather_fur_hide", 2 ]
+    ],
     "proficiencies": [
-      { "proficiency": "prof_leatherworking_basic" },
-      { "proficiency": "prof_leatherworking" },
-      { "proficiency": "prof_closures" },
+      { "proficiency": "prof_leatherworking_basic", "fail_multiplier": 1.1, "time_multiplier": 1.1 },
+      { "proficiency": "prof_leatherworking", "fail_multiplier": 1.1, "time_multiplier": 1.1 },
+      { "proficiency": "prof_closures", "fail_multiplier": 1.1, "time_multiplier": 1.1 },
       { "proficiency": "prof_closures_waterproofing" },
       { "proficiency": "prof_polymerworking" },
       { "proficiency": "prof_metalworking" },
-      { "proficiency": "prof_articulation" },
-      { "proficiency": "prof_welding_basic" }
+      { "proficiency": "prof_articulation", "fail_multiplier": 1.1, "time_multiplier": 1.1 },
+      { "proficiency": "prof_blacksmithing" },
+      { "proficiency": "prof_armorsmithing" },
+      { "proficiency": "prof_quenching" }
     ],
-    "qualities": [ { "id": "LEATHER_AWL", "level": 1 } ],
-    "tools": [ [ [ "welder", 64 ], [ "welder_crude", 97 ], [ "soldering_iron", 97 ], [ "toolset", 97 ] ] ],
+    "qualities": [
+      { "id": "LEATHER_AWL", "level": 1 },
+      { "id": "CHISEL", "level": 3 }
+    ],
+    "tools": [
+      [ [ "welder", 64 ], [ "welder_crude", 97 ], [ "soldering_iron", 97 ], [ "toolset", 97 ] ],
+      [ [ "swage", -1 ] ],
+      [ [ "metal_tank", -1 ] ],
+      [ [ "water", -240 ] ]
+    ],
     "components": [
       [ [ "rag", 10 ], [ "sheet_cotton_patchwork", 10 ], [ "sheet_cotton", 10 ], [ "jumpsuit", 1 ] ],
-      [ [ "leather", 12 ], [ "tanned_hide", 2 ] ],
       [ [ "coat_rain", 1 ], [ "jacket_windbreaker", 1 ], [ "jacket_evac", 1 ], [ "coat_gut", 1 ] ],
-      [ [ "steel_chunk", 4 ], [ "scrap", 12 ], ["lc_steel_lump", 1 ], ["lc_steel_chunk", 4] ],
       [ [ "duct_tape", 300 ] ],
-      [ [ "sheet_kevlar_layered", 30 ], [ "kevlar", 2], [ "swat_armor", 2], [ "ballistic_vest_esapi", 2], [ "ballistic_vest_heavy", 1 ] ]
+      [ [ "sheet_kevlar_layered", 30 ] ]
     ]
   },
   {
@@ -1396,15 +1412,24 @@
     "type": "recipe",
     "activity_level": "MODERATE_EXERCISE",
     "copy-from": "hsurvivor_jumpsuit",
-    "qualities": [ { "id": "LEATHER_AWL", "level": 1 } ],
-    "tools": [ [ [ "welder", 48 ], [ "welder_crude", 72 ], [ "soldering_iron", 72 ], [ "toolset", 72 ] ] ],
+    "using": [
+      [ "sewing_standard", 150 ],
+      [ "blacksmithing_standard", 8 ],
+      [ "mc_steel_standard", 2 ],
+      [ "fabric_leather_fur_hide", 2 ]
+    ],
+    "qualities": [ { "id": "LEATHER_AWL", "level": 1 }, { "id": "CHISEL", "level": 3 } ],
+    "tools": [
+      [ [ "welder", 48 ], [ "welder_crude", 72 ], [ "soldering_iron", 72 ], [ "toolset", 72 ] ],
+      [ [ "swage", -1 ] ],
+      [ [ "metal_tank", -1 ] ],
+      [ [ "water", -240 ] ]
+    ],
     "components": [
       [ [ "rag", 7 ], [ "sheet_cotton_patchwork", 7 ], [ "sheet_cotton", 7 ], [ "jumpsuit", 1 ] ],
-      [ [ "leather", 9 ], [ "tanned_hide", 2 ] ],
       [ [ "coat_rain", 1 ], [ "jacket_windbreaker", 1 ], [ "jacket_evac", 1 ], [ "coat_gut", 1 ] ],
-      [ [ "steel_chunk", 3 ], [ "scrap", 9 ], ["lc_steel_lump", 1 ], ["lc_steel_chunk", 3] ],
       [ [ "duct_tape", 225 ] ],
-      [ [ "sheet_kevlar_layered", 23 ], [ "kevlar", 1], [ "swat_armor", 2], [ "ballistic_vest_esapi", 1], [ "ballistic_vest_heavy", 1 ] ]
+      [ [ "sheet_kevlar_layered", 23 ] ]
     ]
   },
   {
@@ -1412,15 +1437,24 @@
     "type": "recipe",
     "activity_level": "MODERATE_EXERCISE",
     "copy-from": "hsurvivor_jumpsuit",
-    "qualities": [ { "id": "LEATHER_AWL", "level": 1 } ],
-    "tools": [ [ [ "welder", 72 ], [ "welder_crude", 109 ], [ "soldering_iron", 109 ], [ "toolset", 109 ] ] ],
+    "using": [
+      [ "sewing_standard", 300 ],
+      [ "blacksmithing_standard", 15 ],
+      [ "mc_steel_standard", 5 ],
+      [ "fabric_leather_fur_hide", 3 ]
+    ],
+    "qualities": [ { "id": "LEATHER_AWL", "level": 1 }, { "id": "CHISEL", "level": 3 } ],
+    "tools": [
+      [ [ "welder", 72 ], [ "welder_crude", 109 ], [ "soldering_iron", 109 ], [ "toolset", 109 ] ],
+      [ [ "swage", -1 ] ],
+      [ [ "metal_tank", -1 ] ],
+      [ [ "water", -240 ] ]
+    ],
     "components": [
       [ [ "rag", 15 ], [ "sheet_cotton_patchwork", 15 ], [ "sheet_cotton", 15 ], [ "jumpsuit", 1 ] ],
-      [ [ "leather", 18 ], [ "tanned_hide", 3 ] ],
       [ [ "coat_rain", 1 ], [ "jacket_windbreaker", 1 ], [ "jacket_evac", 1 ], [ "coat_gut", 1 ] ],
-      [ [ "steel_chunk", 6 ], [ "scrap", 18 ], ["lc_steel_lump", 2 ], ["lc_steel_chunk", 6] ],
       [ [ "duct_tape", 450 ] ],
-      [ [ "sheet_kevlar_layered", 45 ], [ "kevlar", 3], [ "swat_armor", 3], [ "ballistic_vest_esapi", 3], [ "ballistic_vest_heavy", 2 ] ]
+      [ [ "sheet_kevlar_layered", 45 ] ]
     ]
   },
   {

--- a/data/json/recipes/armor/suit.json
+++ b/data/json/recipes/armor/suit.json
@@ -1377,10 +1377,11 @@
       { "proficiency": "prof_closures_waterproofing" },
       { "proficiency": "prof_polymerworking" },
       { "proficiency": "prof_metalworking" },
-      { "proficiency": "prof_articulation" }
+      { "proficiency": "prof_articulation" },
+      { "proficiency": "prof_welding_basic" }
     ],
     "qualities": [ { "id": "LEATHER_AWL", "level": 1 } ],
-    "tools": [ [ [ "welder", 56 ], [ "welder_crude", 84 ], [ "soldering_iron", 84 ], [ "toolset", 84 ] ] ],
+    "tools": [ [ [ "welder", 64 ], [ "welder_crude", 97 ], [ "soldering_iron", 97 ], [ "toolset", 97 ] ] ],
     "components": [
       [ [ "rag", 10 ], [ "sheet_cotton_patchwork", 10 ], [ "sheet_cotton", 10 ], [ "jumpsuit", 1 ] ],
       [ [ "leather", 12 ], [ "tanned_hide", 2 ] ],
@@ -1396,7 +1397,7 @@
     "activity_level": "MODERATE_EXERCISE",
     "copy-from": "hsurvivor_jumpsuit",
     "qualities": [ { "id": "LEATHER_AWL", "level": 1 } ],
-    "tools": [ [ [ "welder", 42 ], [ "welder_crude", 63 ], [ "soldering_iron", 63 ], [ "toolset", 63 ] ] ],
+    "tools": [ [ [ "welder", 48 ], [ "welder_crude", 72 ], [ "soldering_iron", 72 ], [ "toolset", 72 ] ] ],
     "components": [
       [ [ "rag", 7 ], [ "sheet_cotton_patchwork", 7 ], [ "sheet_cotton", 7 ], [ "jumpsuit", 1 ] ],
       [ [ "leather", 9 ], [ "tanned_hide", 2 ] ],
@@ -1412,7 +1413,7 @@
     "activity_level": "MODERATE_EXERCISE",
     "copy-from": "hsurvivor_jumpsuit",
     "qualities": [ { "id": "LEATHER_AWL", "level": 1 } ],
-    "tools": [ [ [ "welder", 63 ], [ "welder_crude", 95 ], [ "soldering_iron", 95 ], [ "toolset", 95 ] ] ],
+    "tools": [ [ [ "welder", 72 ], [ "welder_crude", 109 ], [ "soldering_iron", 109 ], [ "toolset", 109 ] ] ],
     "components": [
       [ [ "rag", 15 ], [ "sheet_cotton_patchwork", 15 ], [ "sheet_cotton", 15 ], [ "jumpsuit", 1 ] ],
       [ [ "leather", 18 ], [ "tanned_hide", 3 ] ],


### PR DESCRIPTION
-Update recipes for survivor suits

-Only allow specific cotton as well as jumpsuit as base components
-Only allow kevlar armor with appropriate thickness to be replacement for layered kevlar
-Slightly increased kevlar material requirements for normal survivor suit as they gained an extra layer
-Remove additional requirements components of containers as most of the pockets of heavy survivor were removed
-Add basic welding to proficiency for heavy survivor suit as 2 layers of metal will require some welding
-Increase solder/welding charges required for heavy survivor by 15%

-update to tempered steel and add relevant proficiencies to craft



<details>
  <summary>Click to expand!</summary>
  

![](https://i.imgur.com/T26QjWM.png)
</details>
